### PR TITLE
Add conversation manager component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
-# streamlitconvomgr
+# Streamlit Conversation Manager
+
+This repository provides a reusable Streamlit component written in React that renders a list of conversation names with inline action buttons. The component emits events back to Python when a conversation is selected, renamed, or deleted. Styling can be customised via the component parameters or overridden with CSS.
+
+## Features
+
+- List conversations with inline rename and delete buttons
+- Emits `select`, `rename`, and `delete` events to Streamlit
+- Supports custom colours and fonts via props
+- Integrates as a standard Streamlit component
+
+## Usage
+
+```python
+import streamlit as st
+from conversation_component import conversation_manager
+
+convos = ["General", "Support", "Ideas"]
+
+result = conversation_manager(convos, accent_color="#FF4B4B", font_family="Arial")
+
+if result:
+    st.write(result)
+```
+
+## Development
+
+The frontend is a small React project located in `conversation_component/frontend`.
+To develop locally:
+
+```bash
+cd conversation_component/frontend
+npm install
+npm start
+```
+
+Then run `streamlit run example.py` from the project root. To create a production build:
+
+```bash
+npm run build
+```
+
+The build output will be placed under `conversation_component/frontend/build` and used when `_RELEASE` is set to `True` inside `conversation_component/__init__.py`.

--- a/conversation_component/__init__.py
+++ b/conversation_component/__init__.py
@@ -1,0 +1,30 @@
+import os
+import streamlit.components.v1 as components
+
+_RELEASE = False
+
+if _RELEASE:
+    parent_dir = os.path.dirname(os.path.abspath(__file__))
+    build_dir = os.path.join(parent_dir, 'frontend', 'build')
+    _component_func = components.declare_component('conversation_manager', path=build_dir)
+else:
+    _component_func = components.declare_component('conversation_manager', url="http://localhost:3001")
+
+def conversation_manager(conversations, key=None, **style):
+    """Renders the conversation manager.
+
+    Parameters
+    ----------
+    conversations: list[str]
+        List of conversation names.
+    style: dict
+        Styling options passed to the frontend.
+    key: str or None
+        Streamlit key.
+
+    Returns
+    -------
+    dict or None
+        Event information from the frontend or None if no event.
+    """
+    return _component_func(conversations=conversations, style=style, key=key)

--- a/conversation_component/frontend/package.json
+++ b/conversation_component/frontend/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "conversation-component",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@streamlit/component-lib": "^1.5.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "scripts": {
+    "start": "webpack-dev-server --mode development --watch --hot",
+    "build": "webpack --mode production"
+  }
+}

--- a/conversation_component/frontend/public/index.html
+++ b/conversation_component/frontend/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Conversation Manager</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/conversation_component/frontend/src/ConversationManager.tsx
+++ b/conversation_component/frontend/src/ConversationManager.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { Streamlit } from "@streamlit/component-lib";
+
+export interface ConversationManagerProps {
+  conversations: string[];
+  style: { [key: string]: any };
+}
+
+export const ConversationManager = ({ conversations, style }: ConversationManagerProps) => {
+  const handleSelect = (name: string) => {
+    Streamlit.setComponentValue({ event: "select", name });
+  };
+
+  const handleRename = (name: string) => {
+    const newName = window.prompt("Rename conversation", name);
+    if (newName && newName !== name) {
+      Streamlit.setComponentValue({ event: "rename", name, newName });
+    }
+  };
+
+  const handleDelete = (name: string) => {
+    if (window.confirm(`Delete conversation '${name}'?`)) {
+      Streamlit.setComponentValue({ event: "delete", name });
+    }
+  };
+
+  return (
+    <div style={{ fontFamily: style.font_family, color: style.font_color }}>
+      {conversations.map((name) => (
+        <div key={name} style={{ display: "flex", alignItems: "center", marginBottom: 4 }}>
+          <button
+            style={{
+              background: "none",
+              border: "none",
+              color: style.accent_color,
+              cursor: "pointer",
+              marginRight: 4,
+            }}
+            onClick={() => handleSelect(name)}
+          >
+            {name}
+          </button>
+          <span
+            style={{ cursor: "pointer", marginLeft: 4 }}
+            onClick={() => handleRename(name)}
+          >
+            ✏️
+          </span>
+          <span
+            style={{ cursor: "pointer", marginLeft: 4 }}
+            onClick={() => handleDelete(name)}
+          >
+            🗑️
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ConversationManager;

--- a/conversation_component/frontend/src/index.tsx
+++ b/conversation_component/frontend/src/index.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { Streamlit, withStreamlitConnection } from "@streamlit/component-lib";
+import ConversationManager from "./ConversationManager";
+
+const StreamlitConversationManager = withStreamlitConnection(ConversationManager);
+
+ReactDOM.render(
+  <React.StrictMode>
+    <StreamlitConversationManager />
+  </React.StrictMode>,
+  document.getElementById("root")
+);
+
+Streamlit.setComponentReady();
+Streamlit.setFrameHeight(0);

--- a/conversation_component/frontend/tsconfig.json
+++ b/conversation_component/frontend/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "jsx": "react",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}

--- a/conversation_component/frontend/webpack.config.js
+++ b/conversation_component/frontend/webpack.config.js
@@ -1,0 +1,27 @@
+const path = require('path');
+
+module.exports = {
+  entry: './src/index.tsx',
+  output: {
+    path: path.resolve(__dirname, 'build'),
+    filename: 'main.js'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/
+      }
+    ]
+  },
+  resolve: {
+    extensions: ['.tsx', '.ts', '.js']
+  },
+  devServer: {
+    static: {
+      directory: path.join(__dirname, 'public')
+    },
+    port: 3001
+  }
+};

--- a/example.py
+++ b/example.py
@@ -1,0 +1,16 @@
+import streamlit as st
+from conversation_component import conversation_manager
+
+st.title("Conversation Manager Demo")
+
+conversations = ["General", "Support", "Ideas"]
+
+result = conversation_manager(
+    conversations,
+    accent_color="#1f77b4",
+    font_family="sans-serif",
+    key="conv-manager",
+)
+
+if result:
+    st.json(result)


### PR DESCRIPTION
## Summary
- implement Streamlit component in React
- add example usage and development instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ce73994a88325b7623649f6ea9f13